### PR TITLE
feat(66): h2 and postgres profiles added, databases configured

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
@@ -78,6 +83,18 @@
 			<version>${mapstruct.version}</version>
 		</dependency>
 	</dependencies>
+
+	<profiles>
+		<profile>
+			<id>dev-h2</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+		</profile>
+		<profile>
+			<id>dev-postgres</id>
+		</profile>
+	</profiles>
 
 	<build>
 		<plugins>

--- a/src/main/resources/application-dev-h2.yaml
+++ b/src/main/resources/application-dev-h2.yaml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:compstoredb
+    username: user
+    password: test
+    driverClassName: org.h2.Driver
+  jpa:
+    spring.jpa.database-platform: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true

--- a/src/main/resources/application-dev-postgres.yaml
+++ b/src/main/resources/application-dev-postgres.yaml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5431/compstore-postgres
+    username: postgres
+    password: test
+    driver-class-name: org.postgresql.Driver
+  jpa:
+    spring.jpa.database-platform: org.hibernate.dialect.PostgreSQLDialect
+  hibernate:
+    ddl-auto: validate

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,18 +2,8 @@ server:
   port: 8080
 
 spring:
-  datasource:
-    url: jdbc:h2:mem:compstoredb
-    username: user
-    password: test
-    driverClassName: org.h2.Driver
-  jpa:
-    spring.jpa.database-platform: org.hibernate.dialect.H2Dialect
-  h2:
-    console:
-      enabled: true
-  hibernate:
-    ddl-auto: update
+  profiles:
+    active: dev-h2
   liquibase:
     change-log: classpath:/db/changelog/db.changelog-master.yaml
     enabled: true


### PR DESCRIPTION
Utworzyłem 2 profile:
- dev-h2
- dev-postgres

Przy braku wybrania uruchomi się h2.
Utworzyłem dwie konfiguracje (to już musisz zrobić sobie samemu)
![image](https://github.com/grz55/compstore-api/assets/32485116/2faa188d-7edd-4eed-95fa-3bb28517389b)

Wybranie profilu
![image](https://github.com/grz55/compstore-api/assets/32485116/cd098c52-2872-43b7-a9f2-b36733f722a8)

Postawiłem bazę danych na docker:
1. Zainstalowałem docker desktop
2. Pobrałem obraz stąd https://hub.docker.com/_/postgres za pomocą komendy docker pull postgres
3. Utworzyłem kontener `docker run --name comstore-postgres -e POSTGRES_PASSWORD=test-d -p 5431:5432 postgres` (UWAGA: Przy braku mapowania portów na 5431 nie działało mi połączenie z pgAdmina oraz spring boot)
4. Zainstalowałem pgAdmin 4 i połączyłem się do bazy, zmieniłem nazwę bazy na compstore-postgres (tak żeby odpowiadalo z konfiguracji spring boot z profilu dev-postgres)
5. Po uruchomieniu aplikacji dane z liquibase załadowały się do bazy compstore-postgres na schemat public
6. Gdyby podczas testowania aplikacji utworzyło się tam trochę śmieci warto usunąć schemat i uruchomić ponownie. Wtedy schemat postawi się na czysto (komendy staram się robić w cmd żeby komend się uczyć: DROP SCHEMA public CASCADE;
CREATE SCHEMA public;)

Myślę, że na początek taki obraz wystarczy. Podczas ogarniania rendera najwyżej stworzy się bardziej zaawansowany dockerfile
