### PR TITLE
fix(69): cors configuration for profiles

### DIFF
--- a/src/main/java/com/compstore/config/CrossOriginConfig.java
+++ b/src/main/java/com/compstore/config/CrossOriginConfig.java
@@ -1,16 +1,32 @@
 package com.compstore.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
 public class CrossOriginConfig implements WebMvcConfigurer {
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+    @Profile("prod")
+    @Configuration
+    public static class ProdCorsConfig implements WebMvcConfigurer {
+        @Override
+        public void addCorsMappings(CorsRegistry registry) {
+            registry.addMapping("/**")
+                    .allowedOrigins("https://pawelnu.github.io/compstore-ui/")
+                    .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+        }
+    }
+
+    @Profile("!prod")
+    @Configuration
+    public static class DevCorsConfig implements WebMvcConfigurer {
+        @Override
+        public void addCorsMappings(CorsRegistry registry) {
+            registry.addMapping("/**")
+                    .allowedOrigins("http://localhost:3000")
+                    .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+        }
     }
 }


### PR DESCRIPTION
Cel brancha to taka konfiguracja CORS, aby dla profilu produkcyjnego `prod` akceptowało adres z "prawdziwego" zdeployowanego frontendu. Profil prod to będzie ten który pójdzie na render na produkcję.

Dla pozostałych profili (tych, które będziemy uruchamiać lokalnie) chcemy, aby aplikacja akceptowała żądania z lokalnej instancji Reacta

⚠️ **UWAGA**: Do mergowania dopiero po zmergowaniu brancha z utworzeniem profilu `prod` (bo na razie go nie ma)