### PR TITLE
fix(79): cors allowed frontend null fix, bean creation change

### DIFF
--- a/src/main/java/com/compstore/config/CrossOriginConfig.java
+++ b/src/main/java/com/compstore/config/CrossOriginConfig.java
@@ -1,36 +1,41 @@
 package com.compstore.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class CrossOriginConfig implements WebMvcConfigurer {
+public class CrossOriginConfig {
 
     @Value("${cors.allowed-origins}")
-    private static String allowedFrontend;
+    private String allowedFrontend;
 
     @Profile("prod")
-    @Configuration
-    public static class ProdCorsConfig implements WebMvcConfigurer {
-        @Override
-        public void addCorsMappings(CorsRegistry registry) {
-            registry.addMapping("/**")
-                    .allowedOrigins(allowedFrontend)
-                    .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
-        }
+    @Bean
+    public WebMvcConfigurer prodCorsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins(allowedFrontend)
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+            }
+        };
     }
 
     @Profile("!prod")
-    @Configuration
-    public static class DevCorsConfig implements WebMvcConfigurer {
-        @Override
-        public void addCorsMappings(CorsRegistry registry) {
-            registry.addMapping("/**")
-                    .allowedOrigins("http://localhost:3000")
-                    .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
-        }
+    @Bean
+    public WebMvcConfigurer noProdCorsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS");
+            }
+        };
     }
 }


### PR DESCRIPTION
Prawidłowe podpięcie allowedOrigins w CORS